### PR TITLE
feat: gas sponsor service and sponsored TX support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BINARY = envd
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS = -ldflags "-X main.version=$(VERSION)"
 
-.PHONY: build clean test run install
+.PHONY: build clean test run install build-sponsor run-sponsor
 
 build:
 	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/envd
@@ -25,3 +25,9 @@ run: build
 
 install: build
 	cp bin/$(BINARY) /usr/local/bin/$(BINARY)
+
+build-sponsor:
+	go build $(LDFLAGS) -o bin/sponsor-service ./cmd/sponsor-service
+
+run-sponsor: build-sponsor
+	./bin/sponsor-service

--- a/cmd/sponsor-service/main.go
+++ b/cmd/sponsor-service/main.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/block-vision/sui-go-sdk/models"
+	suisdk "github.com/block-vision/sui-go-sdk/sui"
+	internalSui "github.com/fractalmind-ai/fractalmind-envd/internal/sui"
+	"gopkg.in/yaml.v3"
+)
+
+// ServiceConfig is the sponsor-service.yaml configuration.
+type ServiceConfig struct {
+	Listen string    `yaml:"listen"`
+	SUI    SUICfg    `yaml:"sui"`
+	MaxGas uint64    `yaml:"max_gas_per_tx"`
+}
+
+type SUICfg struct {
+	RPC               string `yaml:"rpc"`
+	KeypairPath       string `yaml:"keypair_path"`
+	PackageID         string `yaml:"package_id"`
+	SponsorRegistryID string `yaml:"sponsor_registry_id"`
+}
+
+// SponsorHandler handles POST /sponsor requests.
+type SponsorHandler struct {
+	rpc       suisdk.ISuiAPI
+	keypair   *internalSui.Keypair
+	packageID string
+	maxGas    uint64
+}
+
+func main() {
+	configPath := flag.String("config", "sponsor-service.yaml", "path to config file")
+	flag.Parse()
+
+	log.SetPrefix("[sponsor] ")
+	log.SetFlags(log.Ldate | log.Ltime | log.Lmsgprefix)
+
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	kp, err := internalSui.LoadOrGenerateKeypair(cfg.SUI.KeypairPath)
+	if err != nil {
+		log.Fatalf("load keypair: %v", err)
+	}
+
+	rpc := suisdk.NewSuiClient(cfg.SUI.RPC)
+
+	handler := &SponsorHandler{
+		rpc:       rpc,
+		keypair:   kp,
+		packageID: cfg.SUI.PackageID,
+		maxGas:    cfg.MaxGas,
+	}
+
+	log.Printf("sponsor address: %s", kp.Address())
+	log.Printf("whitelisted package: %s", cfg.SUI.PackageID)
+	log.Printf("max gas per tx: %d MIST", cfg.MaxGas)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /sponsor", handler.handleSponsor)
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	log.Printf("listening on %s", cfg.Listen)
+	if err := http.ListenAndServe(cfg.Listen, mux); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}
+
+func (h *SponsorHandler) handleSponsor(w http.ResponseWriter, r *http.Request) {
+	var req internalSui.SponsorRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Validate required fields
+	if req.Sender == "" || req.Module == "" || req.Function == "" {
+		writeError(w, http.StatusBadRequest, "sender, module, function are required")
+		return
+	}
+
+	// Validate package whitelist
+	if req.PackageID != h.packageID {
+		writeError(w, http.StatusForbidden, fmt.Sprintf("package %s not whitelisted", req.PackageID))
+		return
+	}
+
+	log.Printf("sponsoring %s::%s for sender %s", req.Module, req.Function, req.Sender[:10])
+
+	// Find a gas coin owned by the sponsor
+	gasCoinID, err := h.findGasCoin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("find gas coin: %v", err))
+		return
+	}
+
+	// Build the TX via MoveCall RPC with sender=worker, gas=sponsor's coin
+	// This creates a sponsored TX where gas_owner = sponsor
+	gasBudget := strconv.FormatUint(h.maxGas, 10)
+	txn, err := h.rpc.MoveCall(r.Context(), models.MoveCallRequest{
+		Signer:          req.Sender,
+		PackageObjectId: req.PackageID,
+		Module:          req.Module,
+		Function:        req.Function,
+		TypeArguments:   req.TypeArgs,
+		Arguments:       req.Args,
+		Gas:             &gasCoinID,
+		GasBudget:       gasBudget,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("build tx: %v", err))
+		return
+	}
+
+	// Sign the TX with the sponsor's keypair
+	signed := txn.SignSerializedSigWith(ed25519.PrivateKey(h.keypair.Private))
+
+	resp := internalSui.SponsorResponse{
+		TxBytes:          signed.TxBytes,
+		SponsorSignature: signed.Signature,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+
+	log.Printf("sponsored %s::%s for %s (gas_coin=%s)", req.Module, req.Function, req.Sender[:10], gasCoinID[:10])
+}
+
+// findGasCoin returns the object ID of a SUI gas coin owned by the sponsor.
+func (h *SponsorHandler) findGasCoin(ctx context.Context) (string, error) {
+	resp, err := h.rpc.SuiXGetCoins(ctx, models.SuiXGetCoinsRequest{
+		Owner:    h.keypair.Address(),
+		CoinType: "0x2::sui::SUI",
+		Limit:    1,
+	})
+	if err != nil {
+		return "", fmt.Errorf("get coins: %w", err)
+	}
+
+	if len(resp.Data) == 0 {
+		return "", fmt.Errorf("sponsor has no SUI coins at %s", h.keypair.Address())
+	}
+
+	return resp.Data[0].CoinObjectId, nil
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(internalSui.SponsorErrorResponse{Error: msg})
+}
+
+func loadConfig(path string) (*ServiceConfig, error) {
+	cfg := &ServiceConfig{
+		Listen: ":8081",
+		SUI: SUICfg{
+			RPC:         "https://fullnode.testnet.sui.io:443",
+			KeypairPath: "~/.sui/sponsor.key",
+		},
+		MaxGas: 10000000,
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, err
+	}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+
+	// Validate required fields
+	if cfg.SUI.PackageID == "" {
+		return nil, fmt.Errorf("sui.package_id is required")
+	}
+
+	return cfg, nil
+}
+
+// ValidatePackage checks if a package_id is in the whitelist.
+// Exported for testing.
+func ValidatePackage(packageID, whitelisted string) bool {
+	return strings.EqualFold(packageID, whitelisted)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,14 +39,20 @@ type HeartbeatConfig struct {
 }
 
 type SUIConfig struct {
-	Enabled      bool   `yaml:"enabled"`
-	RPC          string `yaml:"rpc"`
-	KeypairPath  string `yaml:"keypair_path"`
-	PackageID    string `yaml:"package_id"`
-	RegistryID   string `yaml:"registry_id"`
-	OrgID        string `yaml:"org_id"`
-	CertID       string `yaml:"cert_id"`
-	PollInterval string `yaml:"poll_interval"`
+	Enabled      bool          `yaml:"enabled"`
+	RPC          string        `yaml:"rpc"`
+	KeypairPath  string        `yaml:"keypair_path"`
+	PackageID    string        `yaml:"package_id"`
+	RegistryID   string        `yaml:"registry_id"`
+	OrgID        string        `yaml:"org_id"`
+	CertID       string        `yaml:"cert_id"`
+	PollInterval string        `yaml:"poll_interval"`
+	Sponsor      SponsorConfig `yaml:"sponsor"`
+}
+
+type SponsorConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	URL     string `yaml:"url"`
 }
 
 type WireGuardConfig struct {

--- a/internal/sui/client.go
+++ b/internal/sui/client.go
@@ -16,17 +16,19 @@ import (
 type RPCClient interface {
 	MoveCall(ctx context.Context, req models.MoveCallRequest) (models.TxnMetaData, error)
 	SignAndExecuteTransactionBlock(ctx context.Context, req models.SignAndExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
+	SuiExecuteTransactionBlock(ctx context.Context, req models.SuiExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
 	SuiXQueryEvents(ctx context.Context, req models.SuiXQueryEventsRequest) (models.PaginatedEventsResponse, error)
 }
 
 // Client is the SUI blockchain client for peer registry operations.
 type Client struct {
-	rpc        RPCClient
-	keypair    *Keypair
-	packageID  string
+	rpc       RPCClient
+	keypair   *Keypair
+	packageID string
 	registryID string
-	orgID      string
-	certID     string
+	orgID     string
+	certID    string
+	sponsor   *SponsorClient
 }
 
 // NewClient creates a SUI client from config.
@@ -40,14 +42,21 @@ func NewClient(cfg config.SUIConfig) (*Client, error) {
 
 	log.Printf("[sui] address=%s", kp.Address())
 
-	return &Client{
+	c := &Client{
 		rpc:        rpc,
 		keypair:    kp,
 		packageID:  cfg.PackageID,
 		registryID: cfg.RegistryID,
 		orgID:      cfg.OrgID,
 		certID:     cfg.CertID,
-	}, nil
+	}
+
+	if cfg.Sponsor.Enabled && cfg.Sponsor.URL != "" {
+		c.sponsor = NewSponsorClient(cfg.Sponsor.URL)
+		log.Printf("[sui] sponsor enabled: %s", cfg.Sponsor.URL)
+	}
+
+	return c, nil
 }
 
 // newClientWithRPC creates a client with a custom RPC (for testing).
@@ -224,7 +233,16 @@ func (c *Client) PollNewEvents(ctx context.Context, cursor string) ([]PeerInfo, 
 }
 
 // executeMoveCall builds, signs, and executes a Move function call.
+// If sponsor is enabled, routes through the Sponsor Service for gas sponsorship.
 func (c *Client) executeMoveCall(ctx context.Context, module, function string, args []interface{}) error {
+	if c.sponsor != nil {
+		return c.executeViaSponsorship(ctx, module, function, args)
+	}
+	return c.executeDirect(ctx, module, function, args)
+}
+
+// executeDirect builds, signs, and executes a TX directly (self-paying gas).
+func (c *Client) executeDirect(ctx context.Context, module, function string, args []interface{}) error {
 	txn, err := c.rpc.MoveCall(ctx, models.MoveCallRequest{
 		Signer:          c.keypair.Address(),
 		PackageObjectId: c.packageID,
@@ -251,6 +269,45 @@ func (c *Client) executeMoveCall(ctx context.Context, module, function string, a
 		return fmt.Errorf("execute tx: %w", err)
 	}
 
+	return nil
+}
+
+// executeViaSponsorship sends the move call intent to the Sponsor Service,
+// receives back (tx_bytes, sponsor_signature), co-signs with our key, and submits.
+func (c *Client) executeViaSponsorship(ctx context.Context, module, function string, args []interface{}) error {
+	req := SponsorRequest{
+		Sender:    c.keypair.Address(),
+		PackageID: c.packageID,
+		Module:    module,
+		Function:  function,
+		TypeArgs:  []interface{}{},
+		Args:      args,
+	}
+
+	resp, err := c.sponsor.RequestSponsorship(ctx, req)
+	if err != nil {
+		return fmt.Errorf("sponsor request: %w", err)
+	}
+
+	// Co-sign the tx_bytes with our keypair
+	txnMeta := models.TxnMetaData{TxBytes: resp.TxBytes}
+	signed := txnMeta.SignSerializedSigWith(c.keypair.Private)
+
+	// Submit with both signatures (sponsor first, then sender)
+	_, err = c.rpc.SuiExecuteTransactionBlock(ctx, models.SuiExecuteTransactionBlockRequest{
+		TxBytes:   resp.TxBytes,
+		Signature: []string{resp.SponsorSignature, signed.Signature},
+		Options: models.SuiTransactionBlockOptions{
+			ShowEffects: true,
+			ShowEvents:  true,
+		},
+		RequestType: "WaitForLocalExecution",
+	})
+	if err != nil {
+		return fmt.Errorf("execute sponsored tx: %w", err)
+	}
+
+	log.Printf("[sui] sponsored TX executed")
 	return nil
 }
 

--- a/internal/sui/client_test.go
+++ b/internal/sui/client_test.go
@@ -5,6 +5,10 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,6 +20,7 @@ import (
 type mockRPC struct {
 	moveCallFn    func(ctx context.Context, req models.MoveCallRequest) (models.TxnMetaData, error)
 	signExecFn    func(ctx context.Context, req models.SignAndExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
+	execFn        func(ctx context.Context, req models.SuiExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
 	queryEventsFn func(ctx context.Context, req models.SuiXQueryEventsRequest) (models.PaginatedEventsResponse, error)
 }
 
@@ -29,6 +34,13 @@ func (m *mockRPC) MoveCall(ctx context.Context, req models.MoveCallRequest) (mod
 func (m *mockRPC) SignAndExecuteTransactionBlock(ctx context.Context, req models.SignAndExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error) {
 	if m.signExecFn != nil {
 		return m.signExecFn(ctx, req)
+	}
+	return models.SuiTransactionBlockResponse{}, nil
+}
+
+func (m *mockRPC) SuiExecuteTransactionBlock(ctx context.Context, req models.SuiExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error) {
+	if m.execFn != nil {
+		return m.execFn(ctx, req)
 	}
 	return models.SuiTransactionBlockResponse{}, nil
 }
@@ -157,11 +169,11 @@ func TestQueryPeers(t *testing.T) {
 					Data: []models.SuiEventResponse{
 						{
 							ParsedJson: map[string]interface{}{
-								"peer":              peerAddr,
-								"org_id":            "0xorg",
-								"wireguard_pubkey":  hex.EncodeToString(wgKey),
-								"endpoints":         []interface{}{"1.2.3.4:51820"},
-								"hostname":          "peer-host",
+								"peer":             peerAddr,
+								"org_id":           "0xorg",
+								"wireguard_pubkey": hex.EncodeToString(wgKey),
+								"endpoints":        []interface{}{"1.2.3.4:51820"},
+								"hostname":         "peer-host",
 							},
 						},
 					},
@@ -229,6 +241,139 @@ func TestApplyPeerDeregistered(t *testing.T) {
 	}
 	if _, ok := peers["0xpeer2"]; !ok {
 		t.Error("peer2 should still exist")
+	}
+}
+
+func TestExecuteViaSponsorship(t *testing.T) {
+	kp := testKeypair(t)
+
+	// Mock sponsor service
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		var req SponsorRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+
+		if req.Module != "peer" || req.Function != "go_offline" {
+			t.Errorf("expected peer.go_offline, got %s.%s", req.Module, req.Function)
+		}
+
+		if req.Sender != kp.Address() {
+			t.Errorf("expected sender %s, got %s", kp.Address(), req.Sender)
+		}
+
+		// Return mock sponsored TX
+		resp := SponsorResponse{
+			TxBytes:          "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			SponsorSignature: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	var execCalled bool
+	mock := &mockRPC{
+		execFn: func(_ context.Context, req models.SuiExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error) {
+			execCalled = true
+			if len(req.Signature) != 2 {
+				t.Errorf("expected 2 signatures, got %d", len(req.Signature))
+			}
+			return models.SuiTransactionBlockResponse{}, nil
+		},
+	}
+
+	client := newClientWithRPC(mock, kp, "0xpkg", "0xreg", "0xorg", "0xcert")
+	client.sponsor = NewSponsorClient(srv.URL)
+
+	err := client.GoOffline(context.Background())
+	if err != nil {
+		t.Fatalf("GoOffline via sponsor: %v", err)
+	}
+
+	if !execCalled {
+		t.Error("SuiExecuteTransactionBlock should have been called")
+	}
+}
+
+func TestSponsorClientError(t *testing.T) {
+	// Mock sponsor service that returns an error
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(SponsorErrorResponse{Error: "package not whitelisted"})
+	}))
+	defer srv.Close()
+
+	sc := NewSponsorClient(srv.URL)
+
+	_, err := sc.RequestSponsorship(context.Background(), SponsorRequest{
+		Sender:    "0xtest",
+		PackageID: "0xbad",
+		Module:    "peer",
+		Function:  "register_peer",
+	})
+
+	if err == nil {
+		t.Fatal("expected error from sponsor service")
+	}
+	if !hasPrefix(err.Error(), "sponsor service: package not whitelisted") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDirectVsSponsoredRouting(t *testing.T) {
+	kp := testKeypair(t)
+
+	// Without sponsor — should use direct path
+	var directCalled bool
+	mock := &mockRPC{
+		moveCallFn: func(_ context.Context, req models.MoveCallRequest) (models.TxnMetaData, error) {
+			directCalled = true
+			return models.TxnMetaData{}, nil
+		},
+	}
+	client := newClientWithRPC(mock, kp, "0xpkg", "0xreg", "0xorg", "0xcert")
+
+	if err := client.GoOffline(context.Background()); err != nil {
+		t.Fatalf("direct GoOffline: %v", err)
+	}
+	if !directCalled {
+		t.Error("should use direct path when sponsor is nil")
+	}
+
+	// With sponsor — should use sponsor path
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := SponsorResponse{
+			TxBytes:          "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			SponsorSignature: "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	var sponsoredExecCalled bool
+	mock2 := &mockRPC{
+		moveCallFn: func(_ context.Context, req models.MoveCallRequest) (models.TxnMetaData, error) {
+			t.Error("MoveCall should NOT be called in sponsored path")
+			return models.TxnMetaData{}, fmt.Errorf("should not be called")
+		},
+		execFn: func(_ context.Context, req models.SuiExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error) {
+			sponsoredExecCalled = true
+			return models.SuiTransactionBlockResponse{}, nil
+		},
+	}
+	client2 := newClientWithRPC(mock2, kp, "0xpkg", "0xreg", "0xorg", "0xcert")
+	client2.sponsor = NewSponsorClient(srv.URL)
+
+	if err := client2.GoOffline(context.Background()); err != nil {
+		t.Fatalf("sponsored GoOffline: %v", err)
+	}
+	if !sponsoredExecCalled {
+		t.Error("should use sponsored path when sponsor is set")
 	}
 }
 

--- a/internal/sui/sponsor_client.go
+++ b/internal/sui/sponsor_client.go
@@ -1,0 +1,93 @@
+package sui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// SponsorRequest is the request sent to the Sponsor Service.
+type SponsorRequest struct {
+	Sender    string        `json:"sender"`
+	PackageID string        `json:"package_id"`
+	Module    string        `json:"module"`
+	Function  string        `json:"function"`
+	TypeArgs  []interface{} `json:"type_args"`
+	Args      []interface{} `json:"args"`
+}
+
+// SponsorResponse is the response from the Sponsor Service.
+type SponsorResponse struct {
+	TxBytes          string `json:"tx_bytes"`
+	SponsorSignature string `json:"sponsor_signature"`
+}
+
+// SponsorErrorResponse is an error response from the Sponsor Service.
+type SponsorErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// SponsorClient is an HTTP client for the Sponsor Service.
+type SponsorClient struct {
+	url    string
+	client *http.Client
+}
+
+// NewSponsorClient creates a Sponsor Service HTTP client.
+func NewSponsorClient(url string) *SponsorClient {
+	return &SponsorClient{
+		url: url,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// RequestSponsorship sends a move call intent to the Sponsor Service and
+// receives back the sponsored tx_bytes and sponsor's signature.
+func (sc *SponsorClient) RequestSponsorship(ctx context.Context, req SponsorRequest) (*SponsorResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, sc.url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := sc.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp SponsorErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("sponsor service: %s", errResp.Error)
+		}
+		return nil, fmt.Errorf("sponsor service returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result SponsorResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	if result.TxBytes == "" || result.SponsorSignature == "" {
+		return nil, fmt.Errorf("sponsor service returned incomplete response")
+	}
+
+	return &result, nil
+}

--- a/sentinel.yaml.example
+++ b/sentinel.yaml.example
@@ -28,6 +28,9 @@ sui:
   org_id: "0x..."                     # Organization object ID
   cert_id: "0x..."                    # AgentCertificate object ID
   poll_interval: 30s                  # How often to poll for new peer events
+  sponsor:
+    enabled: false
+    url: http://localhost:8081/sponsor # Gas Sponsor Service endpoint
 
 # WireGuard P2P data plane
 wireguard:

--- a/sponsor-service.yaml.example
+++ b/sponsor-service.yaml.example
@@ -1,0 +1,13 @@
+# sponsor-service.yaml — Gas Sponsor Service configuration
+# The sponsor service pays gas fees on behalf of envd worker nodes.
+
+listen: :8081
+
+sui:
+  rpc: https://fullnode.testnet.sui.io:443
+  keypair_path: ~/.sui/sponsor.key              # Ed25519 keypair for the sponsor wallet
+  package_id: "0x74aef8ff3bb0da5d5626780e6c0e5f1f36308a40580e519920fdc9204e73d958"
+  sponsor_registry_id: "0x22db6a75b60b1f530e9779188c62c75a44340723d9d78e21f7e25ded29718511"
+
+# Max gas budget per sponsored transaction (MIST). 10000000 = 0.01 SUI
+max_gas_per_tx: 10000000


### PR DESCRIPTION
## Summary
- **Sponsor Service** (`cmd/sponsor-service/`): Standalone HTTP backend that builds and co-signs SUI sponsored transactions on behalf of envd worker nodes. Validates package whitelist, manages gas coins, and enforces budget limits.
- **Sponsored TX path** (`internal/sui/`): When `sponsor.enabled=true`, the SUI client routes transactions through the Sponsor Service instead of self-paying gas. Worker co-signs the sponsored TX and submits with dual signatures (SIP-15).
- **Config & Makefile**: Added `SponsorConfig` (enabled, url) to SUIConfig. Added `build-sponsor` and `run-sponsor` Makefile targets.

## Sponsor TX Flow
1. Worker sends intent (module, function, args) → Sponsor Service (`POST /sponsor`)
2. Sponsor builds TX via `MoveCall` with sponsor's gas coin, signs it
3. Returns `{tx_bytes, sponsor_signature}` to worker
4. Worker co-signs `tx_bytes`, submits with both signatures via `SuiExecuteTransactionBlock`

## New Files
| File | Purpose |
|------|---------|
| `cmd/sponsor-service/main.go` | HTTP service: POST /sponsor, GET /health |
| `internal/sui/sponsor_client.go` | HTTP client for sponsor service |
| `sponsor-service.yaml.example` | Example config (testnet object IDs) |

## Modified Files
| File | Change |
|------|--------|
| `internal/sui/client.go` | Added `executeViaSponsorship` path, `SuiExecuteTransactionBlock` to RPCClient |
| `internal/sui/client_test.go` | +3 sponsor tests (155 new lines) |
| `internal/config/config.go` | Added `SponsorConfig` struct |
| `sentinel.yaml.example` | Documented sponsor config section |
| `Makefile` | Added `build-sponsor`, `run-sponsor` targets |

## Test plan
- [x] `go test ./...` — all 19 tests pass (10 sui, 7 wg, 2 stun)
- [x] `go vet ./...` — no warnings
- [x] `go build ./cmd/envd/` — compiles
- [x] `go build ./cmd/sponsor-service/` — compiles
- [x] `make build build-sponsor` — both binaries build
- [ ] Manual: run envd with `sponsor.enabled=false` — existing behavior unchanged
- [ ] Manual: run envd + sponsor-service against testnet — TX sponsored successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)