### PR TITLE
feat: macOS support with graceful WireGuard degradation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ tmux      tmux          AI Agent processes
 
 ## Quick Start
 
+### Linux
+
 ```bash
 # Build
 make build
@@ -50,6 +52,76 @@ cp sentinel.yaml.example sentinel.yaml
 
 # Run
 ./bin/envd --config sentinel.yaml
+```
+
+### macOS
+
+envd supports macOS with graceful degradation — WireGuard is optional, and SUI + agent scanning work independently.
+
+```bash
+# Install dependencies
+brew install wireguard-tools go git
+
+# Build (produces bin/envd-darwin-arm64)
+make build-darwin
+# Or: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o bin/envd ./cmd/envd/
+
+# Configure
+cp sentinel.yaml.example sentinel.yaml
+```
+
+**macOS-specific config notes:**
+
+```yaml
+wireguard:
+  enabled: true
+  interface_name: "utun99"    # macOS requires utun[0-9]* names (not wg0)
+  listen_port: 51820
+  keypair_path: "~/.wireguard/envd.key"
+
+stun:
+  enabled: true
+  bind_address: ""            # Set to your physical IP if VPN causes STUN timeouts
+  servers:
+    - stun:stun.l.google.com:19302
+```
+
+- **Interface name:** macOS uses `utun*` format. Set `interface_name: "utun99"` (or any unused utun number).
+- **WireGuard requires root:** `wireguard-go` needs root/sudo to create TUN devices. Run with `sudo` or use a launchd plist.
+- **VPN conflict:** If a VPN is active, STUN may bind to the VPN tunnel address and time out. Set `stun.bind_address` to your physical interface IP (e.g., `192.168.1.100`).
+- **Graceful degradation:** If WireGuard fails (no root, interface creation error), envd continues with SUI registration + agent scanning. WireGuard features are disabled but everything else works.
+
+**Running with launchd (recommended for macOS):**
+
+```bash
+sudo tee /Library/LaunchDaemons/ai.fractalmind.envd.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.fractalmind.envd</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/envd</string>
+        <string>--config</string>
+        <string>/etc/envd/sentinel.yaml</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/envd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/envd.log</string>
+</dict>
+</plist>
+EOF
+
+sudo cp bin/envd /usr/local/bin/envd
+sudo mkdir -p /etc/envd && sudo cp sentinel.yaml /etc/envd/sentinel.yaml
+sudo launchctl load /Library/LaunchDaemons/ai.fractalmind.envd.plist
 ```
 
 ## Configuration

--- a/cmd/envd/main.go
+++ b/cmd/envd/main.go
@@ -79,25 +79,28 @@ func main() {
 	var suiPollTicker *time.Ticker
 	var eventCursor string
 
-	if cfg.SUI.Enabled && cfg.WireGuard.Enabled {
-		log.Printf("SUI + WireGuard integration enabled")
+	if cfg.SUI.Enabled {
+		// --- WireGuard init (optional, graceful degradation) ---
+		if cfg.WireGuard.Enabled {
+			log.Printf("SUI + WireGuard integration enabled")
 
-		// 1. Init WireGuard manager
-		wgClient, err := wgctrl.New()
-		if err != nil {
-			log.Fatalf("failed to create wgctrl client: %v", err)
+			wgClient, err := wgctrl.New()
+			if err != nil {
+				log.Printf("[wg] WARNING: failed to create wgctrl client: %v (continuing without WireGuard)", err)
+			} else {
+				wgManager, err = wg.NewManager(cfg.WireGuard, wgClient)
+				if err != nil {
+					log.Printf("[wg] WARNING: failed to create wg manager: %v (continuing without WireGuard)", err)
+				} else if err := wgManager.Setup(); err != nil {
+					log.Printf("[wg] WARNING: failed to setup wg interface: %v (continuing without WireGuard)", err)
+					wgManager = nil
+				}
+			}
+		} else {
+			log.Printf("SUI enabled (WireGuard disabled)")
 		}
 
-		wgManager, err = wg.NewManager(cfg.WireGuard, wgClient)
-		if err != nil {
-			log.Fatalf("failed to create wg manager: %v", err)
-		}
-
-		if err := wgManager.Setup(); err != nil {
-			log.Fatalf("failed to setup wg interface: %v", err)
-		}
-
-		// 2. Build endpoints list (use NAT detection result from role resolution)
+		// Build endpoints list (use NAT detection result from role resolution)
 		var endpoints []string
 		if activeRoles.PublicEndpoint != "" {
 			endpoints = append(endpoints, activeRoles.PublicEndpoint)
@@ -109,25 +112,31 @@ func main() {
 			endpoints = append(endpoints, fmt.Sprintf("0.0.0.0:%d", cfg.WireGuard.ListenPort))
 		}
 
-		// 3. Init SUI client
+		// Init SUI client (works independently of WireGuard)
 		suiClient, err = sui.NewClient(cfg.SUI)
 		if err != nil {
 			log.Fatalf("failed to create sui client: %v", err)
 		}
 
-		// 4. Register peer on-chain (with relay info if applicable)
+		// Register peer on-chain
 		ctx := context.Background()
-		if err := suiClient.RegisterPeer(ctx, wgManager.PublicKey(), endpoints, cfg.Identity.Hostname); err != nil {
+		var wgPubKey []byte
+		if wgManager != nil {
+			wgPubKey = wgManager.PublicKey()
+		}
+		if err := suiClient.RegisterPeer(ctx, wgPubKey, endpoints, cfg.Identity.Hostname); err != nil {
 			log.Printf("[sui] peer registration failed: %v", err)
 		}
 
-		// 5. Query existing peers and sync WireGuard
-		peers, err := suiClient.QueryPeers(ctx)
-		if err != nil {
-			log.Printf("[sui] failed to query peers: %v", err)
-		} else if len(peers) > 0 {
-			if err := wgManager.SyncPeers(peers); err != nil {
-				log.Printf("[wg] failed to sync peers: %v", err)
+		// Query existing peers and sync WireGuard (only if WG is available)
+		if wgManager != nil {
+			peers, err := suiClient.QueryPeers(ctx)
+			if err != nil {
+				log.Printf("[sui] failed to query peers: %v", err)
+			} else if len(peers) > 0 {
+				if err := wgManager.SyncPeers(peers); err != nil {
+					log.Printf("[wg] failed to sync peers: %v", err)
+				}
 			}
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,8 +91,9 @@ type WireGuardConfig struct {
 }
 
 type STUNConfig struct {
-	Enabled bool     `yaml:"enabled"`
-	Servers []string `yaml:"servers"`
+	Enabled     bool     `yaml:"enabled"`
+	Servers     []string `yaml:"servers"`
+	BindAddress string   `yaml:"bind_address"` // optional: bind STUN probes to this local address (useful when VPN is active)
 }
 
 // DefaultConfig returns a config with sensible defaults.

--- a/internal/roles/roles.go
+++ b/internal/roles/roles.go
@@ -61,7 +61,7 @@ func Resolve(cfg *config.Config) *ActiveRoles {
 
 	// NAT detection for auto roles (relay + stun server)
 	if cfg.STUN.Enabled {
-		natType, publicEndpoint := detectNAT(cfg.STUN.Servers)
+		natType, publicEndpoint := detectNAT(cfg.STUN.Servers, cfg.STUN.BindAddress)
 		roles.NATType = natType
 		roles.PublicEndpoint = publicEndpoint
 
@@ -103,13 +103,13 @@ func Resolve(cfg *config.Config) *ActiveRoles {
 // If both return the same mapped port as local, NAT type is "none" (public IP).
 // If mapped ports differ from local but match each other, "full-cone".
 // If mapped ports differ from each other, "symmetric".
-func detectNAT(servers []string) (NATType, string) {
+func detectNAT(servers []string, bindAddr string) (NATType, string) {
 	if len(servers) == 0 {
 		return NATUnknown, ""
 	}
 
 	// First probe: discover our public endpoint
-	endpoint1, err := stun.DiscoverEndpoint(servers)
+	endpoint1, err := stun.DiscoverEndpoint(servers, bindAddr)
 	if err != nil {
 		log.Printf("[roles] STUN probe 1 failed: %v", err)
 		return NATUnknown, ""
@@ -120,7 +120,7 @@ func detectNAT(servers []string) (NATType, string) {
 	for i, s := range servers {
 		reversed[len(servers)-1-i] = s
 	}
-	endpoint2, err := stun.DiscoverEndpoint(reversed)
+	endpoint2, err := stun.DiscoverEndpoint(reversed, bindAddr)
 	if err != nil {
 		// Single successful probe — assume non-symmetric
 		log.Printf("[roles] STUN probe 2 failed, assuming full-cone: %v", err)

--- a/internal/stun/discover.go
+++ b/internal/stun/discover.go
@@ -16,9 +16,10 @@ import (
 //  3. Public STUN servers (Google/Cloudflare, from config)
 //
 // Returns the first successful endpoint discovery.
-func LayeredDiscover(orgServers, sharedServers, publicServers []string) (string, error) {
+// bindAddr is optional; if non-empty, STUN probes bind to this local address.
+func LayeredDiscover(orgServers, sharedServers, publicServers []string, bindAddr string) (string, error) {
 	if len(orgServers) > 0 {
-		endpoint, err := DiscoverEndpoint(orgServers)
+		endpoint, err := DiscoverEndpoint(orgServers, bindAddr)
 		if err == nil {
 			log.Printf("[stun] resolved via org STUN")
 			return endpoint, nil
@@ -27,7 +28,7 @@ func LayeredDiscover(orgServers, sharedServers, publicServers []string) (string,
 	}
 
 	if len(sharedServers) > 0 {
-		endpoint, err := DiscoverEndpoint(sharedServers)
+		endpoint, err := DiscoverEndpoint(sharedServers, bindAddr)
 		if err == nil {
 			log.Printf("[stun] resolved via shared STUN")
 			return endpoint, nil
@@ -35,15 +36,16 @@ func LayeredDiscover(orgServers, sharedServers, publicServers []string) (string,
 		log.Printf("[stun] shared STUN failed, trying public: %v", err)
 	}
 
-	return DiscoverEndpoint(publicServers)
+	return DiscoverEndpoint(publicServers, bindAddr)
 }
 
 // DiscoverEndpoint uses STUN to discover the public IP:port of this host.
 // Tries servers in order, returns the first successful result.
-func DiscoverEndpoint(servers []string) (string, error) {
+// bindAddr is optional; if non-empty, STUN probes bind to this local address.
+func DiscoverEndpoint(servers []string, bindAddr string) (string, error) {
 	for _, server := range servers {
 		addr := strings.TrimPrefix(server, "stun:")
-		endpoint, err := stunQuery(addr)
+		endpoint, err := stunQuery(addr, bindAddr)
 		if err != nil {
 			log.Printf("[stun] server %s failed: %v", addr, err)
 			continue
@@ -54,8 +56,20 @@ func DiscoverEndpoint(servers []string) (string, error) {
 	return "", fmt.Errorf("all STUN servers failed")
 }
 
-func stunQuery(server string) (string, error) {
-	conn, err := net.DialTimeout("udp", server, 5*time.Second)
+func stunQuery(server, bindAddr string) (string, error) {
+	var conn net.Conn
+	var err error
+
+	if bindAddr != "" {
+		// Bind to specific local address (avoids VPN tunnel routing issues)
+		dialer := net.Dialer{
+			Timeout:   5 * time.Second,
+			LocalAddr: &net.UDPAddr{IP: net.ParseIP(bindAddr)},
+		}
+		conn, err = dialer.Dial("udp", server)
+	} else {
+		conn, err = net.DialTimeout("udp", server, 5*time.Second)
+	}
 	if err != nil {
 		return "", fmt.Errorf("dial: %w", err)
 	}

--- a/internal/stun/discover_test.go
+++ b/internal/stun/discover_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestDiscoverEndpoint_NoServers(t *testing.T) {
-	_, err := DiscoverEndpoint(nil)
+	_, err := DiscoverEndpoint(nil, "")
 	if err == nil {
 		t.Error("expected error with no servers")
 	}
@@ -13,7 +13,7 @@ func TestDiscoverEndpoint_NoServers(t *testing.T) {
 
 func TestDiscoverEndpoint_AllFail(t *testing.T) {
 	// Use invalid addresses that will fail to dial
-	_, err := DiscoverEndpoint([]string{"stun:127.0.0.1:1"})
+	_, err := DiscoverEndpoint([]string{"stun:127.0.0.1:1"}, "")
 	if err == nil {
 		t.Error("expected error when all servers fail")
 	}

--- a/internal/wg/interface_darwin.go
+++ b/internal/wg/interface_darwin.go
@@ -1,0 +1,41 @@
+//go:build darwin
+
+package wg
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// ensureInterface creates a WireGuard interface on macOS using wireguard-go.
+//
+// macOS differences from Linux:
+//   - No kernel WireGuard module; uses wireguard-go (userspace) instead
+//   - Interface names must match utun[0-9]* format (e.g., utun99)
+//   - wireguard-go creates and manages the utun device
+//   - Requires root/sudo for TUN device creation
+//   - wgctrl communicates via /var/run/wireguard/<name>.sock
+func ensureInterface(name string) error {
+	// Check if interface already exists via ifconfig
+	if out, err := exec.Command("ifconfig", name).CombinedOutput(); err == nil {
+		_ = out
+		return nil
+	}
+
+	// Validate interface name for macOS
+	if !strings.HasPrefix(name, "utun") {
+		log.Printf("[wg] WARNING: macOS requires utun* interface names (got %q). "+
+			"Set wireguard.interface_name to e.g. \"utun99\" in your config.", name)
+		return fmt.Errorf("macOS requires utun* interface names, got %q", name)
+	}
+
+	// Use wireguard-go to create the userspace interface
+	if out, err := exec.Command("wireguard-go", name).CombinedOutput(); err != nil {
+		return fmt.Errorf("wireguard-go %s: %s (%w)", name, string(out), err)
+	}
+
+	log.Printf("[wg] created interface %s (via wireguard-go)", name)
+	return nil
+}

--- a/internal/wg/interface_linux.go
+++ b/internal/wg/interface_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package wg
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+)
+
+// ensureInterface creates a kernel WireGuard interface if it does not exist.
+// On Linux, this uses iproute2 commands (ip link add/set).
+func ensureInterface(name string) error {
+	// Check if interface already exists
+	if out, err := exec.Command("ip", "link", "show", name).CombinedOutput(); err == nil {
+		_ = out
+		return nil
+	}
+
+	if out, err := exec.Command("ip", "link", "add", "dev", name, "type", "wireguard").CombinedOutput(); err != nil {
+		return fmt.Errorf("ip link add %s: %s (%w)", name, string(out), err)
+	}
+	if out, err := exec.Command("ip", "link", "set", name, "up").CombinedOutput(); err != nil {
+		return fmt.Errorf("ip link set %s up: %s (%w)", name, string(out), err)
+	}
+	log.Printf("[wg] created interface %s", name)
+	return nil
+}

--- a/internal/wg/manager.go
+++ b/internal/wg/manager.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/netip"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sync"
 	"time"
@@ -78,24 +77,6 @@ func (m *Manager) Setup() error {
 	}
 
 	log.Printf("[wg] interface %s configured (port %d)", m.cfg.InterfaceName, port)
-	return nil
-}
-
-// ensureInterface creates a kernel WireGuard interface if it does not exist.
-func ensureInterface(name string) error {
-	// Check if interface already exists
-	if out, err := exec.Command("ip", "link", "show", name).CombinedOutput(); err == nil {
-		_ = out
-		return nil
-	}
-
-	if out, err := exec.Command("ip", "link", "add", "dev", name, "type", "wireguard").CombinedOutput(); err != nil {
-		return fmt.Errorf("ip link add %s: %s (%w)", name, string(out), err)
-	}
-	if out, err := exec.Command("ip", "link", "set", name, "up").CombinedOutput(); err != nil {
-		return fmt.Errorf("ip link set %s up: %s (%w)", name, string(out), err)
-	}
-	log.Printf("[wg] created interface %s", name)
 	return nil
 }
 

--- a/sentinel.yaml.example
+++ b/sentinel.yaml.example
@@ -36,7 +36,7 @@ sui:
 # WireGuard P2P data plane
 wireguard:
   enabled: false
-  interface_name: wg0
+  interface_name: wg0                    # Linux: any name. macOS: must be utun[0-9]* (e.g. utun99)
   listen_port: 51820
   keypair_path: ~/.wireguard/envd.key # Curve25519 keypair (auto-generated if missing)
   # address: 10.100.X.Y/32            # Auto-assigned from SUI address hash if empty
@@ -45,6 +45,7 @@ wireguard:
 # Also used for role auto-detection: public IP → auto-enable relay + stun_server.
 stun:
   enabled: true                        # Recommended: always enable for NAT detection
+  bind_address: ""                     # Optional: bind STUN probes to this local IP (useful when VPN is active)
   servers:                             # Public STUN fallback (org/shared STUN discovered on-chain)
     - stun:stun.l.google.com:19302
     - stun:stun1.l.google.com:19302


### PR DESCRIPTION
## Summary

- Platform-specific WireGuard interface creation via Go build tags (`interface_linux.go` / `interface_darwin.go`)
- Graceful degradation: WireGuard failure no longer crashes envd — SUI registration + agent scanning continue independently
- Decouple SUI from WireGuard: `cfg.SUI.Enabled` no longer requires `cfg.WireGuard.Enabled`
- STUN bind address config (`stun.bind_address`) to work around VPN tunnel routing on macOS
- macOS Quick Start in README with launchd plist, utun naming, VPN workaround

## Changes

| File | Change |
|------|--------|
| `internal/wg/interface_linux.go` | **NEW** — Linux `ensureInterface` (ip link add/set) |
| `internal/wg/interface_darwin.go` | **NEW** — macOS `ensureInterface` (wireguard-go + utun) |
| `internal/wg/manager.go` | Remove platform-specific code (moved to build-tagged files) |
| `cmd/envd/main.go` | `log.Fatalf` → `log.Printf` for WG failures; decouple SUI from WG |
| `internal/config/config.go` | Add `BindAddress` to `STUNConfig` |
| `internal/stun/discover.go` | Support bind address in STUN probes |
| `internal/roles/roles.go` | Pass bind address to STUN detection |
| `sentinel.yaml.example` | Document macOS interface name + STUN bind address |
| `README.md` | macOS Quick Start section |

## Test plan

- [x] `go build ./...` — passes (Linux)
- [x] `GOOS=darwin GOARCH=arm64 go build ./cmd/envd/` — cross-compile passes
- [x] `go test ./...` — all tests pass
- [ ] Verify on macOS: `wireguard-go utun99` creates interface, envd starts
- [ ] Verify WG degradation: disable WG → envd starts, SUI registers, agent scanning works
- [ ] Verify STUN bind_address: set to physical IP, confirm STUN succeeds through VPN

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)