### PR TITLE
fix: auto-discover AgentCertificate + fix event cursor

### DIFF
--- a/.github/workflows/deploy-envd.yml
+++ b/.github/workflows/deploy-envd.yml
@@ -131,6 +131,7 @@ jobs:
             rpc: https://fullnode.testnet.sui.io:443
             keypair_path: /etc/envd/sui.key
             package_id: '0xc3448b4cfbe7771a9d42b12d3231b4819dc68583e44f39f9f2613d085e90f8f1'
+            protocol_package_id: '0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24'
             registry_id: '0xceaf0c2208cd561e01694e80ca7de37a0b0113856ddb45c032be02bbb1969bee'
             # No org_id — shared mode, not bound to any organization
 
@@ -175,6 +176,7 @@ jobs:
             rpc: https://fullnode.testnet.sui.io:443
             keypair_path: /etc/envd/sui.key
             package_id: '0xc3448b4cfbe7771a9d42b12d3231b4819dc68583e44f39f9f2613d085e90f8f1'
+            protocol_package_id: '0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24'
             registry_id: '0xceaf0c2208cd561e01694e80ca7de37a0b0113856ddb45c032be02bbb1969bee'
             org_id: '0x66f00e15b28696a3824eb23b3cb3f0070d5f0fd1050c7ae32e2e2bce2565f0cb'
 

--- a/cmd/envd/main.go
+++ b/cmd/envd/main.go
@@ -77,7 +77,7 @@ func main() {
 	var suiClient *sui.Client
 	var wgManager *wg.Manager
 	var suiPollTicker *time.Ticker
-	var eventCursor string
+	var eventCursor interface{}
 
 	if cfg.SUI.Enabled && cfg.WireGuard.Enabled {
 		log.Printf("SUI + WireGuard integration enabled")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,14 +53,15 @@ type HeartbeatConfig struct {
 }
 
 type SUIConfig struct {
-	Enabled      bool   `yaml:"enabled"`
-	RPC          string `yaml:"rpc"`
-	KeypairPath  string `yaml:"keypair_path"`
-	PackageID    string `yaml:"package_id"`
-	RegistryID   string `yaml:"registry_id"`
-	OrgID        string `yaml:"org_id"`
-	CertID       string `yaml:"cert_id"`
-	PollInterval string `yaml:"poll_interval"`
+	Enabled           bool   `yaml:"enabled"`
+	RPC               string `yaml:"rpc"`
+	KeypairPath       string `yaml:"keypair_path"`
+	PackageID         string `yaml:"package_id"`
+	ProtocolPackageID string `yaml:"protocol_package_id"`
+	RegistryID        string `yaml:"registry_id"`
+	OrgID             string `yaml:"org_id"`
+	CertID            string `yaml:"cert_id"`
+	PollInterval      string `yaml:"poll_interval"`
 }
 
 // SponsorConfig configures the built-in gas sponsorship role.

--- a/internal/sui/client.go
+++ b/internal/sui/client.go
@@ -18,17 +18,19 @@ type RPCClient interface {
 	SignAndExecuteTransactionBlock(ctx context.Context, req models.SignAndExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
 	SuiExecuteTransactionBlock(ctx context.Context, req models.SuiExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
 	SuiXQueryEvents(ctx context.Context, req models.SuiXQueryEventsRequest) (models.PaginatedEventsResponse, error)
+	SuiXGetOwnedObjects(ctx context.Context, req models.SuiXGetOwnedObjectsRequest) (models.PaginatedObjectsResponse, error)
 }
 
 // Client is the SUI blockchain client for peer registry operations.
 type Client struct {
-	rpc       RPCClient
-	keypair   *Keypair
-	packageID string
-	registryID string
-	orgID     string
-	certID    string
-	sponsor   *SponsorClient
+	rpc               RPCClient
+	keypair           *Keypair
+	packageID         string
+	protocolPackageID string
+	registryID        string
+	orgID             string
+	certID            string
+	sponsor           *SponsorClient
 }
 
 // NewClient creates a SUI client from config.
@@ -43,26 +45,28 @@ func NewClient(cfg config.SUIConfig) (*Client, error) {
 	log.Printf("[sui] address=%s", kp.Address())
 
 	c := &Client{
-		rpc:        rpc,
-		keypair:    kp,
-		packageID:  cfg.PackageID,
-		registryID: cfg.RegistryID,
-		orgID:      cfg.OrgID,
-		certID:     cfg.CertID,
+		rpc:               rpc,
+		keypair:           kp,
+		packageID:         cfg.PackageID,
+		protocolPackageID: cfg.ProtocolPackageID,
+		registryID:        cfg.RegistryID,
+		orgID:             cfg.OrgID,
+		certID:            cfg.CertID,
 	}
 
 	return c, nil
 }
 
 // newClientWithRPC creates a client with a custom RPC (for testing).
-func newClientWithRPC(rpc RPCClient, kp *Keypair, packageID, registryID, orgID, certID string) *Client {
+func newClientWithRPC(rpc RPCClient, kp *Keypair, packageID, protocolPackageID, registryID, orgID, certID string) *Client {
 	return &Client{
-		rpc:        rpc,
-		keypair:    kp,
-		packageID:  packageID,
-		registryID: registryID,
-		orgID:      orgID,
-		certID:     certID,
+		rpc:               rpc,
+		keypair:           kp,
+		packageID:         packageID,
+		protocolPackageID: protocolPackageID,
+		registryID:        registryID,
+		orgID:             orgID,
+		certID:            certID,
 	}
 }
 
@@ -79,8 +83,18 @@ func (c *Client) SetSponsor(sc *SponsorClient) {
 
 // RegisterPeer registers this node on-chain with its WireGuard public key and endpoints.
 // If the peer is already registered (abort code 8001), it calls GoOnline instead.
+// If certID is not configured, auto-discovers or creates an AgentCertificate.
 func (c *Client) RegisterPeer(ctx context.Context, wgPubKey []byte, endpoints []string, hostname string) error {
-	pubKeyHex := hex.EncodeToString(wgPubKey)
+	// Auto-discover cert if not configured
+	if c.certID == "" {
+		certID, err := c.ensureAgentCert(ctx)
+		if err != nil {
+			return fmt.Errorf("ensure agent cert: %w", err)
+		}
+		c.certID = certID
+	}
+
+	pubKeyHex := "0x" + hex.EncodeToString(wgPubKey)
 
 	err := c.executeMoveCall(ctx, "peer", "register_peer", []interface{}{
 		c.registryID,
@@ -218,7 +232,7 @@ func (c *Client) QueryPeers(ctx context.Context) ([]PeerInfo, error) {
 }
 
 // PollNewEvents fetches events since the given cursor and returns updated peers.
-func (c *Client) PollNewEvents(ctx context.Context, cursor string) ([]PeerInfo, string, error) {
+func (c *Client) PollNewEvents(ctx context.Context, cursor interface{}) ([]PeerInfo, interface{}, error) {
 	peers := make(map[string]*PeerInfo)
 	newCursor := cursor
 
@@ -256,7 +270,7 @@ func (c *Client) PollNewEvents(ctx context.Context, cursor string) ([]PeerInfo, 
 		}
 
 		if resp.NextCursor.TxDigest != "" {
-			newCursor = resp.NextCursor.TxDigest
+			newCursor = resp.NextCursor
 		}
 	}
 
@@ -356,7 +370,7 @@ func (c *Client) fetchAllEvents(
 	peers map[string]*PeerInfo,
 	apply func(map[string]interface{}, map[string]*PeerInfo),
 ) error {
-	cursor := ""
+	var cursor interface{} // nil for first request, EventId for subsequent
 	for {
 		resp, err := c.rpc.SuiXQueryEvents(ctx, models.SuiXQueryEventsRequest{
 			SuiEventFilter: models.EventFilterByMoveEventType{
@@ -376,8 +390,132 @@ func (c *Client) fetchAllEvents(
 		if !resp.HasNextPage {
 			break
 		}
-		cursor = resp.NextCursor.TxDigest
+		cursor = resp.NextCursor
 	}
+	return nil
+}
+
+// ensureAgentCert discovers or creates an AgentCertificate for this node.
+// Returns the cert object ID. Requires protocolPackageID to be configured.
+func (c *Client) ensureAgentCert(ctx context.Context) (string, error) {
+	if c.protocolPackageID == "" {
+		return "", fmt.Errorf("protocol_package_id not configured; required for auto cert discovery")
+	}
+
+	certType := fmt.Sprintf("%s::agent::AgentCertificate", c.protocolPackageID)
+	log.Printf("[sui] looking for AgentCertificate (type=%s)", certType)
+
+	// 1. Query owned objects for existing cert
+	resp, err := c.rpc.SuiXGetOwnedObjects(ctx, models.SuiXGetOwnedObjectsRequest{
+		Address: c.keypair.Address(),
+		Query: models.SuiObjectResponseQuery{
+			Filter:  models.ObjectFilterByStructType{StructType: certType},
+			Options: models.SuiObjectDataOptions{ShowType: true},
+		},
+		Limit: 10,
+	})
+	if err != nil {
+		return "", fmt.Errorf("query owned objects: %w", err)
+	}
+
+	for _, obj := range resp.Data {
+		if obj.Data != nil && obj.Data.ObjectId != "" {
+			log.Printf("[sui] found existing AgentCertificate: %s", obj.Data.ObjectId)
+			return obj.Data.ObjectId, nil
+		}
+	}
+
+	// 2. No cert found — self-register as agent (permissionless)
+	log.Printf("[sui] no AgentCertificate found, registering as agent in org %s...", c.orgID)
+	err = c.executeProtocolCall(ctx, "entry", "register_agent", []interface{}{
+		c.orgID,
+		[]string{"envd-node"},
+	})
+	if err != nil {
+		return "", fmt.Errorf("register agent: %w", err)
+	}
+
+	// 3. Query again to find newly created cert
+	resp, err = c.rpc.SuiXGetOwnedObjects(ctx, models.SuiXGetOwnedObjectsRequest{
+		Address: c.keypair.Address(),
+		Query: models.SuiObjectResponseQuery{
+			Filter:  models.ObjectFilterByStructType{StructType: certType},
+			Options: models.SuiObjectDataOptions{ShowType: true},
+		},
+		Limit: 10,
+	})
+	if err != nil {
+		return "", fmt.Errorf("query cert after registration: %w", err)
+	}
+
+	for _, obj := range resp.Data {
+		if obj.Data != nil && obj.Data.ObjectId != "" {
+			log.Printf("[sui] registered agent, cert: %s", obj.Data.ObjectId)
+			return obj.Data.ObjectId, nil
+		}
+	}
+
+	return "", fmt.Errorf("no AgentCertificate found after registration")
+}
+
+// executeProtocolCall builds, signs, and executes a Move call on the protocol package.
+func (c *Client) executeProtocolCall(ctx context.Context, module, function string, args []interface{}) error {
+	if c.sponsor != nil {
+		req := SponsorRequest{
+			Sender:    c.keypair.Address(),
+			PackageID: c.protocolPackageID,
+			Module:    module,
+			Function:  function,
+			TypeArgs:  []interface{}{},
+			Args:      args,
+		}
+		resp, err := c.sponsor.RequestSponsorship(ctx, req)
+		if err != nil {
+			return fmt.Errorf("sponsor request: %w", err)
+		}
+		txnMeta := models.TxnMetaData{TxBytes: resp.TxBytes}
+		signed := txnMeta.SignSerializedSigWith(c.keypair.Private)
+		_, err = c.rpc.SuiExecuteTransactionBlock(ctx, models.SuiExecuteTransactionBlockRequest{
+			TxBytes:   resp.TxBytes,
+			Signature: []string{resp.SponsorSignature, signed.Signature},
+			Options: models.SuiTransactionBlockOptions{
+				ShowEffects: true,
+				ShowEvents:  true,
+			},
+			RequestType: "WaitForLocalExecution",
+		})
+		if err != nil {
+			return fmt.Errorf("execute sponsored tx: %w", err)
+		}
+		return nil
+	}
+
+	txn, err := c.rpc.MoveCall(ctx, models.MoveCallRequest{
+		Signer:          c.keypair.Address(),
+		PackageObjectId: c.protocolPackageID,
+		Module:          module,
+		Function:        function,
+		TypeArguments:   []interface{}{},
+		Arguments:       args,
+		GasBudget:       "10000000",
+	})
+	if err != nil {
+		return fmt.Errorf("build tx: %w", err)
+	}
+
+	_, err = c.rpc.SignAndExecuteTransactionBlock(ctx, models.SignAndExecuteTransactionBlockRequest{
+		TxnMetaData: txn,
+		PriKey:      c.keypair.Private,
+		Options: models.SuiTransactionBlockOptions{
+			ShowEffects: true,
+			ShowEvents:  true,
+		},
+		RequestType: "WaitForLocalExecution",
+	})
+	if err != nil {
+		return fmt.Errorf("execute tx: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/sui/client_test.go
+++ b/internal/sui/client_test.go
@@ -18,10 +18,11 @@ import (
 
 // mockRPC implements RPCClient for testing.
 type mockRPC struct {
-	moveCallFn    func(ctx context.Context, req models.MoveCallRequest) (models.TxnMetaData, error)
-	signExecFn    func(ctx context.Context, req models.SignAndExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
-	execFn        func(ctx context.Context, req models.SuiExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
-	queryEventsFn func(ctx context.Context, req models.SuiXQueryEventsRequest) (models.PaginatedEventsResponse, error)
+	moveCallFn      func(ctx context.Context, req models.MoveCallRequest) (models.TxnMetaData, error)
+	signExecFn      func(ctx context.Context, req models.SignAndExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
+	execFn          func(ctx context.Context, req models.SuiExecuteTransactionBlockRequest) (models.SuiTransactionBlockResponse, error)
+	queryEventsFn   func(ctx context.Context, req models.SuiXQueryEventsRequest) (models.PaginatedEventsResponse, error)
+	ownedObjectsFn  func(ctx context.Context, req models.SuiXGetOwnedObjectsRequest) (models.PaginatedObjectsResponse, error)
 }
 
 func (m *mockRPC) MoveCall(ctx context.Context, req models.MoveCallRequest) (models.TxnMetaData, error) {
@@ -50,6 +51,13 @@ func (m *mockRPC) SuiXQueryEvents(ctx context.Context, req models.SuiXQueryEvent
 		return m.queryEventsFn(ctx, req)
 	}
 	return models.PaginatedEventsResponse{}, nil
+}
+
+func (m *mockRPC) SuiXGetOwnedObjects(ctx context.Context, req models.SuiXGetOwnedObjectsRequest) (models.PaginatedObjectsResponse, error) {
+	if m.ownedObjectsFn != nil {
+		return m.ownedObjectsFn(ctx, req)
+	}
+	return models.PaginatedObjectsResponse{}, nil
 }
 
 func testKeypair(t *testing.T) *Keypair {
@@ -115,7 +123,7 @@ func TestRegisterPeer(t *testing.T) {
 		},
 	}
 
-	client := newClientWithRPC(mock, kp, "0xpkg", "0xreg", "0xorg", "0xcert")
+	client := newClientWithRPC(mock, kp, "0xpkg", "0xproto", "0xreg", "0xorg", "0xcert")
 
 	wgKey := make([]byte, 32)
 	err := client.RegisterPeer(context.Background(), wgKey, []string{"1.2.3.4:51820"}, "test-host")
@@ -139,7 +147,7 @@ func TestGoOffline(t *testing.T) {
 		},
 	}
 
-	client := newClientWithRPC(mock, kp, "0xpkg", "0xreg", "0xorg", "0xcert")
+	client := newClientWithRPC(mock, kp, "0xpkg", "0xproto", "0xreg", "0xorg", "0xcert")
 
 	if err := client.GoOffline(context.Background()); err != nil {
 		t.Fatalf("GoOffline: %v", err)
@@ -185,7 +193,7 @@ func TestQueryPeers(t *testing.T) {
 		},
 	}
 
-	client := newClientWithRPC(mock, kp, "0xpkg", "0xreg", "0xorg", "0xcert")
+	client := newClientWithRPC(mock, kp, "0xpkg", "0xproto", "0xreg", "0xorg", "0xcert")
 
 	peers, err := client.QueryPeers(context.Background())
 	if err != nil {
@@ -287,7 +295,7 @@ func TestExecuteViaSponsorship(t *testing.T) {
 		},
 	}
 
-	client := newClientWithRPC(mock, kp, "0xpkg", "0xreg", "0xorg", "0xcert")
+	client := newClientWithRPC(mock, kp, "0xpkg", "0xproto", "0xreg", "0xorg", "0xcert")
 	client.sponsor = NewSponsorClient(srv.URL)
 
 	err := client.GoOffline(context.Background())
@@ -336,7 +344,7 @@ func TestDirectVsSponsoredRouting(t *testing.T) {
 			return models.TxnMetaData{}, nil
 		},
 	}
-	client := newClientWithRPC(mock, kp, "0xpkg", "0xreg", "0xorg", "0xcert")
+	client := newClientWithRPC(mock, kp, "0xpkg", "0xproto", "0xreg", "0xorg", "0xcert")
 
 	if err := client.GoOffline(context.Background()); err != nil {
 		t.Fatalf("direct GoOffline: %v", err)
@@ -366,7 +374,7 @@ func TestDirectVsSponsoredRouting(t *testing.T) {
 			return models.SuiTransactionBlockResponse{}, nil
 		},
 	}
-	client2 := newClientWithRPC(mock2, kp, "0xpkg", "0xreg", "0xorg", "0xcert")
+	client2 := newClientWithRPC(mock2, kp, "0xpkg", "0xproto", "0xreg", "0xorg", "0xcert")
 	client2.sponsor = NewSponsorClient(srv.URL)
 
 	if err := client2.GoOffline(context.Background()); err != nil {

--- a/sentinel.yaml.example
+++ b/sentinel.yaml.example
@@ -28,9 +28,10 @@ sui:
   rpc: https://fullnode.testnet.sui.io:443
   keypair_path: ~/.sui/envd.key       # Ed25519 keypair (auto-generated if missing)
   package_id: "0x..."                 # fractalmind_envd package on SUI
+  protocol_package_id: "0x..."       # fractalmind_protocol package (for auto agent cert discovery)
   registry_id: "0x..."                # PeerRegistry shared object ID
   org_id: "0x..."                     # Organization object ID
-  cert_id: "0x..."                    # AgentCertificate object ID
+  cert_id: ""                         # AgentCertificate object ID (auto-discovered if empty)
   poll_interval: 30s                  # How often to poll for new peer events
 
 # WireGuard P2P data plane


### PR DESCRIPTION
## Summary
- Auto-discover AgentCertificate via `getOwnedObjects` when cert_id is empty; self-register as agent if none found
- Fix event cursor: use `nil` for initial query instead of empty string `""` (caused "invalid type: string \"\", expected struct EventID")
- Fix pubKeyHex: add `0x` prefix for SUI SDK validation
- Add `protocol_package_id` to SUI config for type-filtered cert discovery
- Update deploy workflows with protocol_package_id

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 10 tests)
- [ ] Deploy to EC2 and verify peer registration succeeds
- [ ] Verify event polling works without cursor error

🤖 Generated with [Claude Code](https://claude.com/claude-code)