### PR TITLE
fix: wire RemovePeer into production lifecycle + guard auth panic

### DIFF
--- a/cmd/envd/main.go
+++ b/cmd/envd/main.go
@@ -27,6 +27,9 @@ import (
 var (
 	version   = "dev"
 	startedAt = time.Now()
+
+	// relayPeers tracks SUI address → relay peer ID for WSS fallback cleanup.
+	relayPeers = make(map[string]uint16)
 )
 
 func main() {
@@ -525,23 +528,57 @@ func syncPeers(wgManager *wg.Manager, wssClient *relay.WSSClient, peers []sui.Pe
 		return
 	}
 
-	// WSS fallback mode: route each peer through the relay
+	// WSS fallback mode: reconcile relay routes
 	ctx := context.Background()
+
+	// Build desired set from incoming peers
+	desired := make(map[string]struct{})
+	for _, p := range peers {
+		if len(p.Endpoints) > 0 && p.Status == sui.PeerStatusOnline {
+			desired[p.Address] = struct{}{}
+		}
+	}
+
+	// Remove relay routes for peers no longer in the desired set
+	for addr, peerID := range relayPeers {
+		if _, ok := desired[addr]; !ok {
+			if err := wssClient.RemovePeer(ctx, peerID); err != nil {
+				log.Printf("[wss-client] failed to remove stale peer %s: %v", truncAddr(addr), err)
+			} else {
+				log.Printf("[wss-client] removed stale relay route for %s", truncAddr(addr))
+			}
+			delete(relayPeers, addr)
+		}
+	}
+
+	// Add relay routes for new peers, skip already-routed ones
 	for i, p := range peers {
-		if len(p.Endpoints) == 0 {
+		if len(p.Endpoints) == 0 || p.Status != sui.PeerStatusOnline {
 			continue
 		}
-		localAddr, _, err := wssClient.AddPeer(ctx, p.Endpoints[0])
+		if _, routed := relayPeers[p.Address]; routed {
+			continue // already has an active relay route
+		}
+		localAddr, peerID, err := wssClient.AddPeer(ctx, p.Endpoints[0])
 		if err != nil {
-			log.Printf("[wss-client] failed to add peer %s via relay: %v", p.Address[:10], err)
+			log.Printf("[wss-client] failed to add peer %s via relay: %v", truncAddr(p.Address), err)
 			continue
 		}
+		relayPeers[p.Address] = peerID
 		// Rewrite endpoint to the local proxy address
 		peers[i].Endpoints = []string{localAddr}
-		log.Printf("[wss-client] peer %s routed via local proxy %s", p.Address[:10], localAddr)
+		log.Printf("[wss-client] peer %s routed via local proxy %s", truncAddr(p.Address), localAddr)
 	}
 
 	if err := wgManager.SyncPeers(peers); err != nil {
 		log.Printf("[wg] failed to sync peers: %v", err)
 	}
+}
+
+// truncAddr safely truncates an address for logging.
+func truncAddr(s string) string {
+	if len(s) > 16 {
+		return s[:16]
+	}
+	return s
 }

--- a/internal/relay/wshandler.go
+++ b/internal/relay/wshandler.go
@@ -358,7 +358,7 @@ func verifyAuth(msg ControlMsg, nonce []byte) error {
 	derivedAddr := "0x" + hex.EncodeToString(hash[:])
 
 	if derivedAddr != msg.SUiAddress {
-		return fmt.Errorf("address mismatch: derived %s, claimed %s", derivedAddr[:16], msg.SUiAddress[:16])
+		return fmt.Errorf("address mismatch: derived %s, claimed %s", truncAddr(derivedAddr), truncAddr(msg.SUiAddress))
 	}
 
 	return nil
@@ -398,4 +398,12 @@ func (h *WSSHandler) Close() {
 		h.usedPort[alloc.udpPort] = false
 		delete(h.clients, addr)
 	}
+}
+
+// truncAddr safely truncates an address string for log/error messages.
+func truncAddr(s string) string {
+	if len(s) > 16 {
+		return s[:16]
+	}
+	return s
 }


### PR DESCRIPTION
Fixes #13

## Summary
- **RemovePeer wired into production**: `syncPeers` now tracks relay peer IDs and calls `wssClient.RemovePeer` for peers that go offline or are deregistered, preventing relay route leaks
- **Auth panic guarded**: `verifyAuth` no longer panics on short SUI address strings — uses `truncAddr()` helper for safe truncation

## Changes

### `cmd/envd/main.go`
- Add `relayPeers` map (`map[string]uint16`) tracking SUI address → relay peer ID
- Rewrite `syncPeers` WSS fallback path to:
  - Remove stale relay routes for peers no longer in desired set
  - Skip re-adding peers that already have active relay routes
  - Exclude offline peers (`Status != PeerStatusOnline`)
- Add `truncAddr()` for safe address truncation in log messages

### `internal/relay/wshandler.go`
- Replace `msg.SUiAddress[:16]` with `truncAddr(msg.SUiAddress)` in `verifyAuth` error formatting
- Add `truncAddr()` helper (length guard before slice)

## Test plan
- [x] `go build ./...` — compiles clean
- [x] `go test -race ./...` — all tests pass
- [ ] QA review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
