### PR TITLE
feat: auto-discover relay URL from SUI chain

### DIFF
--- a/cmd/envd/main.go
+++ b/cmd/envd/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -16,6 +17,7 @@ import (
 	"github.com/fractalmind-ai/fractalmind-envd/internal/config"
 	"github.com/fractalmind-ai/fractalmind-envd/internal/heartbeat"
 	"github.com/fractalmind-ai/fractalmind-envd/internal/relay"
+	"github.com/fractalmind-ai/fractalmind-envd/internal/relaypicker"
 	"github.com/fractalmind-ai/fractalmind-envd/internal/roles"
 	"github.com/fractalmind-ai/fractalmind-envd/internal/sponsor"
 	"github.com/fractalmind-ai/fractalmind-envd/internal/sui"
@@ -174,10 +176,16 @@ func main() {
 	var wssClient *relay.WSSClient
 
 	if activeRoles.Relay {
+		// Extract bare IP from "ip:port" endpoint
+		relayIP := activeRoles.PublicEndpoint
+		if host, _, err := net.SplitHostPort(relayIP); err == nil {
+			relayIP = host
+		}
+
 		// Combined STUN + Relay on shared UDP port
 		relayServer = relay.NewServer(relay.Config{
 			ListenPort:     cfg.Relay.ListenPort,
-			PublicIP:       activeRoles.PublicEndpoint,
+			PublicIP:       relayIP,
 			MaxConnections: cfg.Relay.MaxConnections,
 		})
 		if err := relayServer.Start(); err != nil {
@@ -188,15 +196,7 @@ func main() {
 
 		// Start WSS relay handler if tcp_fallback config is present
 		if cfg.Relay.TCPFallback && activeRoles.PublicEndpoint != "" {
-			publicIP := activeRoles.PublicEndpoint
-			// Extract IP from "ip:port"
-			for i := len(publicIP) - 1; i >= 0; i-- {
-				if publicIP[i] == ':' {
-					publicIP = publicIP[:i]
-					break
-				}
-			}
-			wssHandler = relay.NewWSSHandler(publicIP, cfg.Relay.WSSPortMin, cfg.Relay.WSSPortMax)
+			wssHandler = relay.NewWSSHandler(relayIP, cfg.Relay.WSSPortMin, cfg.Relay.WSSPortMax)
 			mux := http.NewServeMux()
 			mux.Handle("/wg-relay", wssHandler)
 			wssAddr := fmt.Sprintf(":%d", cfg.Relay.WSSListenPort)
@@ -230,23 +230,47 @@ func main() {
 	}
 
 	// ======= WSS relay client (for UDP-restricted nodes) =======
-	if activeRoles.TCPFallbackActive && cfg.Relay.RelayURL != "" && suiClient != nil {
-		wssClient = relay.NewWSSClient(
-			cfg.Relay.RelayURL,
-			suiClient.Address(),
-			suiClient.Keypair(),
-			fmt.Sprintf("127.0.0.1:%d", cfg.WireGuard.ListenPort),
-		)
-		ctx := context.Background()
-		relayEndpoint, err := wssClient.Connect(ctx)
-		if err != nil {
-			log.Printf("[wss-client] failed to connect to relay: %v", err)
-			wssClient = nil
+	if activeRoles.TCPFallbackActive && suiClient != nil {
+		relayURL := cfg.Relay.RelayURL
+
+		// Auto-discover relay from SUI chain when no relay_url configured
+		if relayURL == "" {
+			ctx := context.Background()
+			peers, err := suiClient.QueryPeers(ctx)
+			if err != nil {
+				log.Printf("[wss-client] failed to query peers for relay discovery: %v", err)
+			} else {
+				picker := relaypicker.NewPicker(cfg.SUI.OrgID, cfg.Relay.Region, cfg.Relay.ISP, relaypicker.NewRelayLoadCache())
+				candidates := picker.SelectBest(peers, 1)
+				if len(candidates) > 0 && candidates[0].Peer.RelayAddr != "" {
+					relayURL = fmt.Sprintf("wss://%s/wg-relay", candidates[0].Peer.RelayAddr)
+					log.Printf("[wss-client] auto-discovered relay: %s (score=%d)", relayURL, candidates[0].Score)
+				} else {
+					log.Printf("[wss-client] no suitable relay found via SUI chain")
+				}
+			}
 		} else {
-			log.Printf("[wss-client] connected via WSS relay, endpoint: %s", relayEndpoint)
-			// Update SUI registration with the relay endpoint
-			if err := suiClient.UpdateEndpoints(ctx, []string{relayEndpoint}); err != nil {
-				log.Printf("[wss-client] failed to update SUI endpoint: %v", err)
+			log.Printf("[wss-client] using configured relay_url: %s", relayURL)
+		}
+
+		if relayURL != "" {
+			wssClient = relay.NewWSSClient(
+				relayURL,
+				suiClient.Address(),
+				suiClient.Keypair(),
+				fmt.Sprintf("127.0.0.1:%d", cfg.WireGuard.ListenPort),
+			)
+			ctx := context.Background()
+			relayEndpoint, err := wssClient.Connect(ctx)
+			if err != nil {
+				log.Printf("[wss-client] failed to connect to relay: %v", err)
+				wssClient = nil
+			} else {
+				log.Printf("[wss-client] connected via WSS relay, endpoint: %s", relayEndpoint)
+				// Update SUI registration with the relay endpoint
+				if err := suiClient.UpdateEndpoints(ctx, []string{relayEndpoint}); err != nil {
+					log.Printf("[wss-client] failed to update SUI endpoint: %v", err)
+				}
 			}
 		}
 	}

--- a/internal/roles/roles.go
+++ b/internal/roles/roles.go
@@ -47,9 +47,9 @@ type ActiveRoles struct {
 	StunServer  bool
 	Sponsor     bool
 
-	NATType          NATType
-	PublicEndpoint   string // Discovered public IP:port (empty if behind NAT)
-	TCPFallbackActive bool  // True when UDP is completely blocked and WSS relay is needed
+	NATType           NATType
+	PublicEndpoint    string // Discovered public IP:port (empty if behind NAT)
+	TCPFallbackActive bool   // True when UDP is completely blocked and WSS relay is needed
 }
 
 // Resolve determines which roles are active based on config and NAT detection.
@@ -97,7 +97,8 @@ func Resolve(cfg *config.Config) *ActiveRoles {
 	}
 
 	// TCP fallback detection: when STUN fails AND tcp_fallback is configured
-	if roles.NATType == NATUnknown && cfg.Relay.TCPFallback && cfg.Relay.RelayURL != "" {
+	// relay_url is no longer required — the node can auto-discover relays from SUI chain
+	if roles.NATType == NATUnknown && cfg.Relay.TCPFallback {
 		// STUN failed — probe UDP connectivity to confirm UDP is blocked
 		if !probeUDP(cfg.STUN.Servers) {
 			roles.TCPFallbackActive = true

--- a/internal/roles/roles_test.go
+++ b/internal/roles/roles_test.go
@@ -116,16 +116,16 @@ func TestResolve_TCPFallback_Activated(t *testing.T) {
 	}
 }
 
-func TestResolve_TCPFallback_NotActivated_NoRelayURL(t *testing.T) {
+func TestResolve_TCPFallback_Activated_NoRelayURL(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.STUN.Enabled = false
 	cfg.Relay.TCPFallback = true
-	cfg.Relay.RelayURL = "" // empty relay URL
+	cfg.Relay.RelayURL = "" // empty relay URL — auto-discovery will find relay from SUI chain
 
 	r := Resolve(cfg)
 
-	if r.TCPFallbackActive {
-		t.Error("TCPFallbackActive should be false when relay_url is empty")
+	if !r.TCPFallbackActive {
+		t.Error("TCPFallbackActive should be true even without relay_url (auto-discovery)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- When `relay_url` is not configured, auto-discover the best relay by querying peers from SUI chain and scoring with `relaypicker` (org match, region, ISP, latency, load)
- If `relay_url` is set in config, use it as manual override (preserves existing behavior)
- Fix `PublicEndpoint` containing `IP:port` being passed to relay server `PublicIP` (now extracts bare IP via `net.SplitHostPort`)
- Remove `relay_url` requirement from `TCPFallbackActive` condition in roles resolver

## EC2 Deployment

Deployed to `43.167.175.47` with WSS relay config:
```
[relay] STUN + Relay server started on 0.0.0.0:3478 (public IP: 43.167.175.47, max conns: 200)
[wss-relay] WSS relay server listening on :8443 (plain HTTP)
```

## Test plan

- [x] `go test ./...` all pass
- [x] `gofmt -w .` applied
- [x] EC2 deployed and WSS relay server listening on :8443
- [ ] QA: verify auto-discovery selects correct relay when multiple relays registered on SUI
- [ ] QA: verify relay_url override still works when configured

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)