### PR TITLE
fix: register relay on SUI chain at startup

### DIFF
--- a/cmd/envd/main.go
+++ b/cmd/envd/main.go
@@ -215,6 +215,19 @@ func main() {
 				}
 			}()
 		}
+
+		// Register as relay on SUI chain so clients can auto-discover this relay
+		if suiClient != nil {
+			wssPort := cfg.Relay.WSSListenPort
+			if cfg.Relay.WSSExternalPort > 0 {
+				wssPort = cfg.Relay.WSSExternalPort
+			}
+			relayAddr := fmt.Sprintf("%s:%d", relayIP, wssPort)
+			capacity := uint64(cfg.Relay.MaxConnections)
+			if err := suiClient.RegisterRelay(context.Background(), relayAddr, cfg.Relay.Region, cfg.Relay.ISP, capacity); err != nil {
+				log.Printf("[sui] relay registration failed: %v", err)
+			}
+		}
 	} else if activeRoles.StunServer {
 		// STUN-only server (no relay capability)
 		stunOnlyServer = relay.NewStunOnlyServer(cfg.Relay.ListenPort)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,13 +83,14 @@ type RelayConfig struct {
 	ISP            string `yaml:"isp"`
 
 	// TCP fallback: WSS relay for UDP-restricted networks (Issue #8)
-	TCPFallback  bool   `yaml:"tcp_fallback"`     // Enable WSS fallback when UDP fails
-	RelayURL     string `yaml:"relay_url"`         // WSS relay endpoint (e.g., "wss://relay.example.com/wg-relay")
-	WSSListenPort int   `yaml:"wss_listen_port"`   // WSS server port for relay nodes (default: 443)
-	WSSCertFile  string `yaml:"wss_cert_file"`     // TLS certificate file (if empty, plain HTTP — requires reverse proxy for TLS)
-	WSSKeyFile   string `yaml:"wss_key_file"`      // TLS private key file
-	WSSPortMin   int    `yaml:"wss_port_min"`      // UDP port pool start for WSS clients (default: 51900)
-	WSSPortMax   int    `yaml:"wss_port_max"`      // UDP port pool end for WSS clients (default: 51999)
+	TCPFallback     bool   `yaml:"tcp_fallback"`      // Enable WSS fallback when UDP fails
+	RelayURL        string `yaml:"relay_url"`         // WSS relay endpoint (e.g., "wss://relay.example.com/wg-relay")
+	WSSListenPort   int    `yaml:"wss_listen_port"`   // WSS server port for relay nodes (default: 443)
+	WSSExternalPort int    `yaml:"wss_external_port"` // External WSS port for relay_addr (e.g., 443 when iptables redirects 443→8443)
+	WSSCertFile     string `yaml:"wss_cert_file"`     // TLS certificate file (if empty, plain HTTP — requires reverse proxy for TLS)
+	WSSKeyFile      string `yaml:"wss_key_file"`      // TLS private key file
+	WSSPortMin      int    `yaml:"wss_port_min"`      // UDP port pool start for WSS clients (default: 51900)
+	WSSPortMax      int    `yaml:"wss_port_max"`      // UDP port pool end for WSS clients (default: 51999)
 }
 
 type WireGuardConfig struct {


### PR DESCRIPTION
## Summary

- Call `suiClient.RegisterRelay()` after WSS relay handler starts so `relay_addr` is visible on-chain for client auto-discovery
- Add `WSSExternalPort` config field (`wss_external_port`) for iptables redirect scenarios (e.g., external 443 → internal 8443)
- Logic: if `WSSExternalPort > 0`, use it for `relay_addr`; else use `WSSListenPort`

## Files changed

| File | Change |
|------|--------|
| `cmd/envd/main.go` | Call `RegisterRelay()` after WSS handler, use `WSSExternalPort` for relay_addr |
| `internal/config/config.go` | Add `WSSExternalPort int` to `RelayConfig` struct |

## EC2 Deployment

Config updated with `region: ap-southeast`, `isp: tencent`, `wss_external_port: 443`. Relay registration call is wired and executes:
```
[relay] STUN + Relay server started on 0.0.0.0:3478 (public IP: 43.167.175.47, max conns: 200)
[relay] relay server enabled on :3478 (region=ap-southeast, isp=tencent)
[wss-relay] WSS relay server listening on :8443 (plain HTTP)
[sui] relay registration failed: register relay: build tx: Cannot find gas coin...
```
Registration fails due to empty wallet (testnet faucet rate-limited). Code path is correct — will succeed once wallet is funded.

## Test plan

- [x] `go test ./...` all pass
- [x] `go test -race ./...` all pass
- [x] `gofmt -w .` applied
- [x] EC2 deployed with updated config
- [ ] QA: fund wallet and verify `relay_addr` visible on-chain
- [ ] QA: verify client auto-discovery finds this relay

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)