### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 # Config (local)
 sentinel.yaml
 *.local.yaml
+
+# Worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` to support parallel development with git worktrees
- envd team now has 2 dev agents (EMP_0004 + EMP_0021) working on the same repo simultaneously

## Test plan
- [x] Verify `.worktrees/` directory is ignored by `git check-ignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)